### PR TITLE
allow the iterator to start with multiple input nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dag-iterator",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "utility tool to traverse DAG graphs in JavaScript",
   "main": "dist/node/index.js",
   "types": "dist/node/index.d.ts",

--- a/src/dag.ts
+++ b/src/dag.ts
@@ -71,19 +71,20 @@ export function iterate<T>(nodes: INode<T>[], edges: IEdge[],
     return unvisited === false ? childNodes : childNodes.filter(filterNotVisited);
   }
 
+  // Initialize the stacks with all the nodes that have no parents.
   Array.prototype.push.apply(nodeStack, getFirstNodes());
 
   while (nodeStack.length) {
-    // Take a layer from the stack
-    const node = nodeStack.pop();
+    // Take the top layer from the stack
+    const node = nodeStack.shift();
 
     // Collect the previous Layers
     const parentNodes = getParentNodes(node);
 
     // Mark this node as visited and record its layer count as
     // max(parents) + 1
-    nodeVisited[node] = parentNodes.reduce(function (accu, curr) {
-      return (accu > nodeVisited[curr] + 1) ? accu : nodeVisited[curr] + 1;
+    nodeVisited[node] = parentNodes.reduce((prev, curr) => {
+      return Math.max(prev, nodeVisited[curr] + 1);
     }, 0);
 
     // Get the layer and previous layers

--- a/src/dag.ts
+++ b/src/dag.ts
@@ -75,8 +75,8 @@ export function iterate<T>(nodes: INode<T>[], edges: IEdge[],
   Array.prototype.push.apply(nodeStack, getFirstNodes());
 
   while (nodeStack.length) {
-    // Take the top layer from the stack
-    const node = nodeStack.shift();
+    // Take the latest layer from the stack
+    const node = nodeStack.pop();
 
     // Collect the previous Layers
     const parentNodes = getParentNodes(node);


### PR DESCRIPTION
Seed the iterator with the input and constant nodes (which do not have
parent nodes).
calculate the node's layer number based on the max of parents' layer number + 1.

This feature is needed for iterating tensor flow frozen graph, which has
constant node.

thanks.